### PR TITLE
Handled exceptions in CatalogImporter

### DIFF
--- a/ImportXC/Services/Importers/CatalogImporter.cs
+++ b/ImportXC/Services/Importers/CatalogImporter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrderCloud.Catalyst;
@@ -22,33 +23,47 @@ namespace ImportXC.Services.Importers
         public async Task Import()
         {
             Console.WriteLine("Importing catalogs");
-            
+
             var catalogFileNames = Directory.EnumerateFiles(this.importFolder, "Catalog.*.json");
             var catalogs = new List<Catalog>();
-            
+
             foreach (var catalogFileName in catalogFileNames)
             {
                 JObject catalogsJson = JObject.Parse(File.ReadAllText(catalogFileName));
                 foreach (var catalogJson in catalogsJson["$values"])
                 {
                     var catalogId = catalogJson["FriendlyId"].ToString();
-                    var catalog = await client.Catalogs.GetAsync(catalogId);
-
-                    if (catalog == null)
+                    try
                     {
-                        Console.WriteLine($"Creating catalog {catalogId}...");
-                        catalog = new Catalog
+                        var catalog = await client.Catalogs.GetAsync(catalogId);
+
+                    }
+                    catch (OrderCloudException ex)
+                    {
+                        if (ex.HttpStatus == HttpStatusCode.NotFound) // Object does not exist
                         {
-                            ID = catalogId,
-                            Name = catalogJson["Name"].ToString(),
-                            Active = true,
-                            Description = catalogJson["DisplayName"].ToString()
-                        };
-                        catalogs.Add(catalog);
+                            try
+                            {
+                                Console.WriteLine($"Creating catalog {catalogId}...");
+                                var catalog = new Catalog
+                                {
+                                    ID = catalogId,
+                                    Name = catalogJson["Name"].ToString(),
+                                    Active = true,
+                                    Description = catalogJson["DisplayName"].ToString()
+                                };
+                                catalogs.Add(catalog);
+                            }
+                            catch (OrderCloudException e)
+                            {
+                                Console.WriteLine(e);
+                                throw;
+                            }
+                        }
                     }
                 }
             }
-            
+
             await Throttler.RunAsync(catalogs, 100, 20, catalog => client.Catalogs.CreateAsync(catalog));
         }
     }


### PR DESCRIPTION
Added try/catch to the CatalogImporter, in the same fashion as CategoryImporter/ProductImporter, as was crashing on unhandled exception when catalog did not exist.